### PR TITLE
fix: Now the body of the delete method is optional

### DIFF
--- a/library/modules/api/api.ts
+++ b/library/modules/api/api.ts
@@ -51,7 +51,7 @@ class Api extends Events {
 	put(route: string, specs: object): Promise<any> {
 		return this.action('put', route, specs);
 	}
-	delete(route: string, specs: object): Promise<any> {
+	delete(route: string, specs?: object): Promise<any> {
 		return this.action('delete', route, specs);
 	}
 


### PR DESCRIPTION
When trying to implement the delete method of the package I found that for the delete method the body is not optional, it is 100% necessary, researching I realized that it should be optional so this PR makes it optional.

https://stackoverflow.com/questions/299628/is-an-entity-body-allowed-for-an-http-delete-request
![image](https://github.com/balearesg/http-suite/assets/90587911/9d49e4f6-b300-4239-af81-1b7c43cc28cf)
