### PR TITLE
Add content-type check for JSON or Blob response in execute method

### DIFF
--- a/library/modules/api/api.ts
+++ b/library/modules/api/api.ts
@@ -29,8 +29,8 @@ class Api extends Events {
 	#getResponse = () => {
 		this.trigger('stream.response');
 	};
-	async action(method = 'get', route: string, specs: object = {}): Promise<any> {
-		return this.#fetcher[method](this.getURL(route), specs);
+	async action(method = 'get', route: string, specs: object = {}, header?: Record<string, string>): Promise<any> {
+		return this.#fetcher[method](this.getURL(route), specs, header);
 	}
 
 	getURL(route: string): string {
@@ -41,18 +41,18 @@ class Api extends Events {
 		this.#fetcher.bearer(bearer);
 		return this;
 	}
-	get(route: string, specs?: object): Promise<any> {
-		return this.action('get', route, specs);
+	get(route: string, specs?: object, header?: Record<string, string>): Promise<any> {
+		return this.action('get', route, specs, header);
 	}
 
-	post(route: string, specs: object): Promise<any> {
-		return this.action('post', route, specs);
+	post(route: string, specs: object, header?: Record<string, string>): Promise<any> {
+		return this.action('post', route, specs, header);
 	}
-	put(route: string, specs: object): Promise<any> {
-		return this.action('put', route, specs);
+	put(route: string, specs: object, header?: Record<string, string>): Promise<any> {
+		return this.action('put', route, specs, header);
 	}
-	delete(route: string, specs?: object): Promise<any> {
-		return this.action('delete', route, specs);
+	delete(route: string, specs?: object, header?: Record<string, string>): Promise<any> {
+		return this.action('delete', route, specs, header);
 	}
 
 	stream(route: string, specs: object = {}): Promise<any> {

--- a/library/modules/api/jcall.ts
+++ b/library/modules/api/jcall.ts
@@ -112,7 +112,13 @@ class JCall extends ReactiveModel<JCall> {
 			if (stream) return this.#streamer.execute(url, specs);
 
 			const response: Response = await fetch(url, specs);
-			return response.json();
+			const contentType = response.headers.get('Content-Type');
+
+			if (contentType && contentType.includes('application/json')) {
+				return response.json();
+			} else {
+				return response.blob();
+			}
 		} catch (e) {
 			console.error('error jcall', e);
 		}

--- a/library/modules/api/jcall.ts
+++ b/library/modules/api/jcall.ts
@@ -1,12 +1,12 @@
 import { ReactiveModel } from '@beyond-js/reactive/model';
 import { Stream } from './stream';
 
-interface headers {
+interface headers extends Record<string, string> {
 	'Content-Type': string;
 }
 
 export /*bundle*/
-	class JCall extends ReactiveModel<JCall> {
+class JCall extends ReactiveModel<JCall> {
 	get actions() {
 		return this.#streamer.actions;
 	}
@@ -58,12 +58,8 @@ export /*bundle*/
 		return this.#formData;
 	};
 
-	#processGetParams(
-		params: Record<string, string>
-	): URLSearchParams | string {
-		const emptyParams: boolean =
-			Object.entries(params).length === 0 &&
-			params.constructor === Object;
+	#processGetParams(params: Record<string, string>): URLSearchParams | string {
+		const emptyParams: boolean = Object.entries(params).length === 0 && params.constructor === Object;
 		if (emptyParams) return '';
 		const parameters: URLSearchParams = new URLSearchParams();
 		for (const key in params) {
@@ -75,9 +71,7 @@ export /*bundle*/
 	}
 
 	#processPostParams = (params, multipart): FormData | string => {
-		const emptyParams: boolean =
-			Object.entries(params).length === 0 &&
-			params.constructor === Object;
+		const emptyParams: boolean = Object.entries(params).length === 0 && params.constructor === Object;
 		if (emptyParams) return;
 
 		if (multipart) {
@@ -100,10 +94,7 @@ export /*bundle*/
 				headersSpecs = {};
 			}
 			const multipart = params.multipart;
-			let headers = this.getHeaders(
-				{ ...headersSpecs, bearer: params.bearer },
-				multipart
-			);
+			let headers = this.getHeaders({ ...headersSpecs, bearer: params.bearer }, multipart);
 			delete params.multipart;
 			delete params.bearer;
 
@@ -114,8 +105,7 @@ export /*bundle*/
 			if (method === 'post' || method === 'put' || method === 'DELETE') {
 				specs.body = this.#processPostParams(params, multipart);
 			} else if (method === 'get') {
-				const queryString: string =
-					this.#processGetParams(params).toString();
+				const queryString: string = this.#processGetParams(params).toString();
 				if (queryString) url += `?${queryString}`;
 			}
 

--- a/library/modules/api/stream.ts
+++ b/library/modules/api/stream.ts
@@ -39,7 +39,6 @@ export class Stream {
 		try {
 			this.#metadata.parsed.value = JSON.parse(metadata.value);
 		} catch (exc) {
-			console.log(metadata);
 			console.error(exc);
 			this.#metadata.parsed.error = 'Error parsing metadata';
 		}


### PR DESCRIPTION
# Add content-type check for JSON or Blob response in execute method

## Description
This PR introduces a condition in the `execute` method of the `jcall.ts` file to handle responses based on their `Content-Type` header. The response will now return JSON if the `Content-Type` is `application/json`, otherwise, it will return a Blob. This improves the flexibility of the wrapper by ensuring the response format aligns with the data type returned by the server.

### Changes
- Updated `execute` method in `library\modules\api\jcall.ts` to check the `Content-Type` header of HTTP responses.
- If the `Content-Type` includes `application/json`, the response will return `JSON`.
- For other types, it will return a Blob.

- No breaking changes introduced

## Additional notes
This enhancement ensures the response data type is processed correctly based on the `Content-Type`, enhancing compatibility with various API responses.
